### PR TITLE
Fix offer instantiation with attribute collision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add extra filter options (tenancy, license_model, preinstalled_software) when fetching EC2 reserved prices (#4)
+* Fix a bug where attribute collisions would cause an exception on offer instantiation (#5)
 
 ## 1.0.0
 

--- a/awspricing/offers.py
+++ b/awspricing/offers.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import logging
 
 from typing import Any, Dict, List, Optional, Set, Type  # noqa
 
@@ -11,7 +12,11 @@ from .constants import (
     EC2_PURCHASE_OPTION,
 )
 
+
 OFFER_CLASS_MAP = {}
+
+
+logger = logging.getLogger(__name__)
 
 
 def implements(offer_name):
@@ -90,9 +95,21 @@ class AWSOffer(object):
                                       ):
         # type: (...) -> Dict[str, str]
 
+        """Generate a reverse mapping from a hash of product attributes to SKU.
+
+        Only hashes that are unique across all products will be included in the
+        result; products which collide on hash will be discarded.
+        """
+
         product_family = kwargs.get('product_family')
 
         result = {}  # type: Dict[str, str]
+
+        # There are cases where the set of attributes are not unique across all
+        # products and cause hash collisions. In these cases, we take note of
+        # the collision and do not include these products in the mapping.
+        attribute_collisions = set()
+
         for sku, product in six.iteritems(self._offer_data['products']):
             if (product_family is not None and
                     product['productFamily'] != product_family):
@@ -100,8 +117,16 @@ class AWSOffer(object):
             attrs = [product['attributes'][attr] for attr in attribute_names]
             key = self.hash_attributes(*attrs)
             if key in result:
-                raise ValueError("Attribute collision for: {}".format(key))
-            result[key] = sku
+                # There is an attribute collision, so do not include any of
+                # these results in the reverse mapping.
+                attribute_collisions.add(key)
+                del result[key]
+            elif key not in attribute_collisions:
+                result[key] = sku
+
+        logger.debug('Discarded {} products when generating reverse mapping.'
+                     .format(len(attribute_collisions)))
+
         return result
 
 

--- a/tests/unit/test_offers.py
+++ b/tests/unit/test_offers.py
@@ -1,12 +1,14 @@
-from awspricing.offers import AWSOffer
+import copy
 
 import pytest
+
+from awspricing.offers import AWSOffer
 
 from tests.data.ec2_offer import BASIC_EC2_OFFER_DATA, BASIC_EC2_OFFER_SKU
 
 
-@pytest.fixture()
-def offer():
+@pytest.fixture(name='offer')
+def basic_offer():
     return AWSOffer(BASIC_EC2_OFFER_DATA)
 
 
@@ -15,15 +17,6 @@ class TestAWSOffer(object):
     def test_raw(self, offer):
         assert 'version' in offer.raw
         assert 'products' in offer.raw
-
-    def test_search_skus_empty(self, offer):
-        assert offer.search_skus() == {BASIC_EC2_OFFER_SKU}
-
-    def test_search_skus_attributes(self, offer):
-        assert offer.search_skus(
-            instance_type='c4.large',
-            location='US East (N. Virginia)',
-        ) == {BASIC_EC2_OFFER_SKU}
 
     def test_pythonify_attributes(self):
         attrs = {'instance_type': 'c4.large', 'currentGeneration': 'Yes'}
@@ -48,3 +41,33 @@ class TestAWSOffer(object):
 
     def test_normalize_region_short(self, offer):
         assert offer._normalize_region('us-east-1') == 'US East (N. Virginia)'
+
+    def test_generate_reverse_sku_mapping(self, offer):
+        assert offer._generate_reverse_sku_mapping(
+            'instanceType', 'operatingSystem', 'tenancy'
+        ) == {'c4.large|Linux|Shared': BASIC_EC2_OFFER_SKU}
+
+    def test_generate_reverse_sku_mapping_collision(self, offer):
+        collision_sku = 'collision_sku'
+
+        # Create a copy of the offer_data, as we're modifying it.
+        offer._offer_data = copy.deepcopy(offer.raw)
+
+        # Add an identical product (in terms of attributes) with a different SKU
+        offer.raw['products'][collision_sku] = offer.raw['products'][BASIC_EC2_OFFER_SKU]
+
+        assert offer._generate_reverse_sku_mapping(
+            'instanceType', 'operatingSystem', 'tenancy'
+        ) == {}
+
+
+class TestEC2Offer(object):
+
+    def test_search_skus_empty(self, offer):
+        assert offer.search_skus() == {BASIC_EC2_OFFER_SKU}
+
+    def test_search_skus_attributes(self, offer):
+        assert offer.search_skus(
+            instance_type='c4.large',
+            location='US East (N. Virginia)',
+        ) == {BASIC_EC2_OFFER_SKU}


### PR DESCRIPTION
The attributes being used to generate a reverse mapping in EC2 were no longer unique after the introduction of the`f1` family. This ensures that collisions just remove the products from the reverse mapping instead of throwing errors.

The downside of this is that these products (`f1` for now) can't be searched with the helper methods (e.g `ondemand_hourly`); however prices can be found directly using `search_skus` and then traversing the raw data as a workaround. I'll revisit this approach in future to see how we can accommodate.