### PR TITLE
bump to version 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.1.5
+
+ * Add capacitystatus attribute for EC2 (#29)
+
 ## 1.1.4
 
  * Include bare metal instance offers for EC2 (#19)

--- a/awspricing/__init__.py
+++ b/awspricing/__init__.py
@@ -6,7 +6,7 @@ from .offers import AWSOffer, get_offer_class  # noqa
 from .cache import maybe_read_from_cache, maybe_write_to_cache
 
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"
 
 
 session = requests.Session()


### PR DESCRIPTION
Bumping version to 1.1.5

Version adds `capacitystatus` as an attribute to EC2 offerings