### PR TITLE
Adding support for EBS Volume pricing including pricing PIOPS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,6 +45,15 @@ Usage
       region='us-east-1'
     )  # 0.10845205479452055
 
+    ec2_offer.ebs_volume(
+      volume_type='gp2',
+      region='us-east-1'
+    ) # 0.10 per GB per Month
+
+    ec2_offer.ebs_iops(
+      region='us-east-1'
+    ) # 0.065 per Provisioned IOP per Month, for io1 volumes
+
     rds_offer = awspricing.offer('AmazonRDS')
 
     rds_offer.search_skus(

--- a/awspricing/constants.py
+++ b/awspricing/constants.py
@@ -51,6 +51,13 @@ REGION_SHORTS = {
     'us-gov-east-1': 'AWS GovCloud (US-East)'
 }
 
+VOLUME_TYPE_SHORTS = {
+    'gp2': 'General Purpose',
+    'sc1': 'Cold HDD',
+    'standard': 'Magnetic',
+    'io1': 'Provisioned IOPS',
+    'st1': 'Throughput Optimized HDD'
+}
 
 EC2_LEASE_CONTRACT_LENGTH = Enum(one_year='1yr', three_year='3yr')
 EC2_OFFERING_CLASS = Enum('standard', 'convertible')

--- a/tests/data/ebs_offer.py
+++ b/tests/data/ebs_offer.py
@@ -1,0 +1,90 @@
+
+BASIC_EBS_OFFER_SKU = 'HY3BZPP2B6K8MSJF'
+BASIC_IOPS_OFFER_SKU = 'D8RDVC722HKNR55G'
+BASIC_EBS_OFFER_DATA = {
+    'HY3BZPP2B6K8MSJF': {
+        'serviceCode': 'AmazonEC2',
+        'product': {
+            'productFamily': 'Storage',
+            'sku' : 'HY3BZPP2B6K8MSJF',
+            'attributes' : {
+                'servicecode' : 'AmazonEC2',
+                'location' : 'US East (N. Virginia)',
+                'locationType' : 'AWS Region',
+                'storageMedia' : 'SSD-backed',
+                'volumeType' : 'General Purpose',
+                'maxVolumeSize' : '16 TiB',
+                'maxIopsvolume' : '16000',
+                'maxIopsBurstPerformance' : '3000 for volumes <= 1 TiB',
+                'maxThroughputvolume' : '250 MiB/s',
+                'usagetype' : 'EBS:VolumeUsage.gp2',
+                'operation' : '',
+                'servicename' : 'Amazon Elastic Compute Cloud'
+            },
+        },
+        'terms': {
+            'OnDemand': {
+                'HY3BZPP2B6K8MSJF.JRTCKXETXF' : {
+                    'offerTermCode' : 'JRTCKXETXF',
+                    'sku' : 'HY3BZPP2B6K8MSJF',
+                    'effectiveDate' : '2019-05-01T00:00:00Z',
+                    'priceDimensions' : {
+                        'HY3BZPP2B6K8MSJF.JRTCKXETXF.6YS6EN2CT7' : {
+                            'rateCode' : 'HY3BZPP2B6K8MSJF.JRTCKXETXF.6YS6EN2CT7',
+                            'description' : '$0.10 per GB-month of General Purpose SSD (gp2) provisioned storage - US East (Northern Virginia)',
+                            'beginRange' : '0',
+                            'endRange' : 'Inf',
+                            'unit' : 'GB-Mo',
+                            'pricePerUnit' : {
+                                'USD' : '0.1000000000'
+                            },
+                            'appliesTo' : [ ]
+                        }
+                    },
+                    "termAttributes" : { }
+                }
+            }
+        }
+    },
+    'D8RDVC722HKNR55G' : {
+        'servicecode' : 'AmazonEC2',
+        'product' : {
+            'productFamily' : 'System Operation',
+            'sku' : 'D8RDVC722HKNR55G',
+            'attributes' : {
+                'servicecode' : 'AmazonEC2',
+                'location' : 'US East (N. Virginia)',
+                'locationType' : 'AWS Region',
+                'provisioned' : 'Yes',
+                'group' : 'EBS IOPS',
+                'groupDescription' : 'IOPS',
+                'usagetype' : 'EBS:VolumeP-IOPS.piops',
+                'operation' : '',
+                'servicename' : 'Amazon Elastic Compute Cloud'
+            }
+        },
+        'terms': {
+            'OnDemand': {
+                'D8RDVC722HKNR55G.JRTCKXETXF' : {
+                    'offerTermCode' : 'JRTCKXETXF',
+                    'sku' : 'D8RDVC722HKNR55G',
+                    'effectiveDate' : '2019-05-01T00:00:00Z',
+                    'priceDimensions' : {
+                        'D8RDVC722HKNR55G.JRTCKXETXF.6YS6EN2CT7' : {
+                            'rateCode' : 'D8RDVC722HKNR55G.JRTCKXETXF.6YS6EN2CT7',
+                            'description' : '$0.065 per IOPS-month provisioned - US East (Northern Virginia)',
+                            'beginRange' : '0',
+                            'endRange' : 'Inf',
+                            'unit' : 'IOPS-Mo',
+                            'pricePerUnit' : {
+                                'USD' : '0.0650000000'
+                            },
+                            'appliesTo' : [ ]
+                        }
+                    },
+                    "termAttributes" : { }
+                }
+            }
+        }
+    }
+}

--- a/tests/unit/test_ebs_offers.py
+++ b/tests/unit/test_ebs_offers.py
@@ -1,0 +1,25 @@
+import copy
+
+import pytest
+import sys
+
+from awspricing.offers import EC2Offer
+
+from tests.data.ebs_offer import (
+    BASIC_EBS_OFFER_SKU,
+    BASIC_IOPS_OFFER_SKU,
+    BASIC_EBS_OFFER_DATA
+)
+
+class TestEBSOffer(object):
+
+    @pytest.fixture(name='ebs_offer')
+    def ebs_offer(self):
+        offer = EC2Offer(BASIC_EBS_OFFER_DATA)
+        return offer
+
+    def test_ebs_offer(self, ebs_offer):
+        assert ebs_offer.ebs_volume('gp2', region='us-east-1') == .1
+
+    def test_ebs_iops_offer(self, ebs_offer):
+        assert ebs_offer.ebs_iops(region='us-east-1') == 0.065


### PR DESCRIPTION
This is my first ever pull request...bear with me I'm not sure how all this works yet. ;)

I've added support I needed for pricing EBS volumes to get a more complete picture of EC2 pricing.  I did my best to keep the code design and style matching the project's current patterns.  Test harness and usage updates included.  I've click signed the Lyft agreement.

Although I did consider breaking out EBS into its own object, ultimately I mixed it into the EC2Offer object as EBS is part of the same AmazonEC2 service and given the current design wouldn't make sense to break out.  In the long term I'm not sure how well that will scale given how much AWS throws into the EC2 bucket (VPC, ELB, etc), but for now it works well enough.
