### PR TITLE
paginated responses for client.describe_services call to capture all services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.1
+ * Use a paginator to retrieve service list from AWS API and fetch all AWS services
+
 ## 2.0.0
 
  * Migrate to use AWS Price List query API instead of offer files

--- a/awspricing/__init__.py
+++ b/awspricing/__init__.py
@@ -7,7 +7,7 @@ from .offers import AWSOffer, get_offer_class  # noqa
 from .cache import maybe_read_from_cache, maybe_write_to_cache
 
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"
 
 _SERVICES = {}  # type: Dict[str, Type[AWSOffer]]
 service_list = []  # type: List[str]

--- a/awspricing/__init__.py
+++ b/awspricing/__init__.py
@@ -60,8 +60,11 @@ def _fetch_offer(offer_name, version=None):
 
 
 def all_services_names():
-    resp = client.describe_services()
-    services = [x['ServiceCode'] for x in resp['Services']]
+    paginator = client.get_paginator('describe_services')
+    resp_pages = paginator.paginate()
+    services = []
+    for page in resp_pages:
+        services.extend([x['ServiceCode'] for x in page['Services']])
     return services
 
 


### PR DESCRIPTION
With AWS expanding their results, this failed to fetch `service=AmazonRedshift` since we didn't fetch the second page of results to get all AWS services. Uses AWS paginator to iterate through all page results and collect all service names. 