### PR TITLE
add skip_cleanup and skip_existing to travis.yml for pypi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ script:
 - make test
 - if [[ $TRAVIS_PYTHON_VERSION == '3.6' ]]; then make test_mypy; fi
 deploy:
+  skip_cleanup: true
+  skip_existing: true
   provider: pypi
   user: lyftpypi
   password:


### PR DESCRIPTION
Noticed our last couple releases have failed Travis CI on this error: 
```
Could not restore untracked files from stash entry
PyPI upload failed.
failed to deploy
```
Added these two skips as discussed here: 
https://github.com/amey-sam/Flask-MailGun/issues/28
https://github.com/amey-sam/Flask-MailGun/pull/29
