### PR TITLE
add longform_description_type to setup.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 2.0.3
+ * Add long_description_content_type to setup.py for pypi deployment
+
 ## 2.0.2
  * Add skips to travis.yml for pypi deployment
 

--- a/awspricing/__init__.py
+++ b/awspricing/__init__.py
@@ -7,7 +7,7 @@ from .offers import AWSOffer, get_offer_class  # noqa
 from .cache import maybe_read_from_cache, maybe_write_to_cache
 
 
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 _SERVICES = {}  # type: Dict[str, Type[AWSOffer]]
 service_list = []  # type: List[str]

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     version=get_version(),
     description='An SDK for AWS Pricing',
     long_description=open('README.rst').read(),
+    long_description_content_type="text/markdown",
     author='Garrett Heel',
     author_email='capacity@lyft.com',
     url='https://github.com/lyft/awspricing',


### PR DESCRIPTION
Addressing error in the pypi deployment:
```
HTTPError: 400 Client Error: The description failed to render in the default format of reStructuredText. See https://pypi.org/help/#description-content-type for more information. for url: https://upload.pypi.org/legacy/
```